### PR TITLE
Refactored ignore nodes when copying scaffold files in a project build. ...

### DIFF
--- a/library/Golem/Scaffold.php
+++ b/library/Golem/Scaffold.php
@@ -21,6 +21,14 @@ class Golem_Scaffold {
 	protected $_target;
 
 	/**
+ 	 * Files / dirs to ignore when copying the Garp_Scaffold files to a blank project.
+ 	 */
+	protected $_ignores = array(
+		'garp',
+		'.travis.yml'
+	);
+
+	/**
  	 * Class constructor
  	 * @param String $scaffoldRepo Scaffold repository
  	 * @param String $target Path to destination directory
@@ -66,7 +74,7 @@ class Golem_Scaffold {
  		 * Git subtree will get confused later on if we try to use this 
  		 * folder as a subtree without going through the proper channels.
  		 */
-		if ($node->getBasename() == 'garp') {
+		if (in_array($node->getBasename(), $this->_ignores)) {
 			return;
 		}
 


### PR DESCRIPTION
...Added Travis configuration to ignore nodes, since this is the Travis config file for Garp_Scaffold, not a template for new files.
